### PR TITLE
fix: Ensure A2A_AGENT_CLIENT_MAX_CHAT_COMPLETION_ITERATIONS environment variable is respected

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ func main() {
 		WithConfig(&cfg.A2A.AgentConfig).
 		WithLLMClient(llmClient).
 		WithToolBox(toolBox).
+		WithMaxChatCompletion(cfg.A2A.AgentConfig.MaxChatCompletionIterations).
 		WithSystemPrompt(`You are an expert N8N workflow automation assistant. Your role is to help users build powerful automation workflows using N8N.
 
 Your primary capabilities:


### PR DESCRIPTION
Fixes ##8

The AgentBuilder.WithConfig method was calling config.NewWithDefaults which resets configuration values to their defaults, ignoring user-provided environment variables. This caused A2A_AGENT_CLIENT_MAX_CHAT_COMPLETION_ITERATIONS to always default to 10 instead of respecting the user's setting.

Added WithMaxChatCompletion call after WithConfig to explicitly override the problematic default and ensure the environment variable value is used.

Generated with [Claude Code](https://claude.ai/code)