### PR TITLE
feat(validation): Add N8N workflow validation skill

### DIFF
--- a/agent.yaml
+++ b/agent.yaml
@@ -33,6 +33,30 @@ spec:
           - query
       inject:
         - logger
+    - id: validate_n8n_workflow
+      name: validate_n8n_workflow
+      description: Validate N8N workflow YAML/JSON to ensure it follows the correct schema and has all required attributes before creating artifacts
+      tags:
+       - validation
+       - workflow
+       - n8n
+       - yaml
+       - json
+      schema:
+        type: object
+        properties:
+          workflow_content:
+            type: string
+            description: The complete N8N workflow content to validate (YAML or JSON format)
+          format:
+            type: string
+            enum: ["yaml", "json", "auto"]
+            description: The format of the workflow content (auto-detect if not specified)
+            default: "auto"
+        required:
+          - workflow_content
+      inject:
+        - logger
   agent:
     provider: ""
     model: ""
@@ -42,6 +66,7 @@ spec:
       Your primary capabilities:
       1. **Documentation Search**: Use the search_n8n_docs skill to search through comprehensive N8N node documentation to find the right nodes for any task
       2. **Workflow Generation**: Create complete, working N8N workflow YAML files based on user requirements using your knowledge and the create_artifact tool
+      3. **Workflow Validation**: Use the validate_n8n_workflow skill to ensure all workflows are valid before creating artifacts
 
       Key knowledge areas:
       - 497+ N8N nodes including standard nodes and LangChain AI nodes
@@ -72,12 +97,17 @@ spec:
       - Include proper node IDs, parameters, connections, and positions
       - Add error handling and best practices
 
-      Step 3: Save as artifact (MANDATORY)
+      Step 3: Validate the workflow (MANDATORY)
+      - Use validate_n8n_workflow to ensure the workflow is valid
+      - Fix any validation errors before proceeding
+      - Repeat validation until the workflow passes all checks
+
+      Step 4: Save as artifact (MANDATORY)
       - Use the create_artifact tool to save the workflow YAML
       - Filename should be descriptive (e.g., "customer_onboarding_workflow.yaml")
       - Content must be valid YAML format
 
-      Step 4: Respond concisely
+      Step 5: Respond concisely
       - Provide a brief 2-3 sentence description
       - Include the artifact download link
       - List required configuration steps

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/inference-gateway/adk v0.15.0
 	github.com/sethvargo/go-envconfig v1.3.0
 	go.uber.org/zap v1.27.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -69,5 +70,4 @@ require (
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -51,6 +51,11 @@ func main() {
 	toolBox.AddTool(searchN8NDocsSkill)
 	l.Info("registered skill: search_n8n_docs (Search through N8N node documentation to find relevant information about specific nodes, their parameters, and usage patterns)")
 
+	// Register validate_n8n_workflow skill
+	validateN8NWorkflowSkill := skills.NewValidateN8NWorkflowSkill(l)
+	toolBox.AddTool(validateN8NWorkflowSkill)
+	l.Info("registered skill: validate_n8n_workflow (Validate N8N workflow YAML/JSON to ensure it follows the correct schema and has all required attributes before creating artifacts)")
+
 	llmClient, err := server.NewOpenAICompatibleLLMClient(&cfg.A2A.AgentConfig, l)
 	if err != nil {
 		l.Fatal("failed to create LLM client", zap.Error(err))
@@ -66,6 +71,7 @@ func main() {
 Your primary capabilities:
 1. **Documentation Search**: Use the search_n8n_docs skill to search through comprehensive N8N node documentation to find the right nodes for any task
 2. **Workflow Generation**: Create complete, working N8N workflow YAML files based on user requirements using your knowledge and the create_artifact tool
+3. **Workflow Validation**: Use the validate_n8n_workflow skill to ensure all workflows are valid before creating artifacts
 
 Key knowledge areas:
 - 497+ N8N nodes including standard nodes and LangChain AI nodes
@@ -96,12 +102,17 @@ Step 2: Generate the complete workflow YAML
 - Include proper node IDs, parameters, connections, and positions
 - Add error handling and best practices
 
-Step 3: Save as artifact (MANDATORY)
+Step 3: Validate the workflow (MANDATORY)
+- Use validate_n8n_workflow to ensure the workflow is valid
+- Fix any validation errors before proceeding
+- Repeat validation until the workflow passes all checks
+
+Step 4: Save as artifact (MANDATORY)
 - Use the create_artifact tool to save the workflow YAML
 - Filename should be descriptive (e.g., "customer_onboarding_workflow.yaml")
 - Content must be valid YAML format
 
-Step 4: Respond concisely
+Step 5: Respond concisely
 - Provide a brief 2-3 sentence description
 - Include the artifact download link
 - List required configuration steps

--- a/skills/validate_n8n_workflow.go
+++ b/skills/validate_n8n_workflow.go
@@ -361,7 +361,7 @@ func (s *ValidateN8NWorkflowSkill) validateWorkflowLogic(workflow *N8NWorkflow, 
 		result.Warnings = append(result.Warnings, "Workflow has no trigger nodes - it cannot be executed automatically")
 	}
 
-	// Additional logic validation could be added here:
+	// TODOs - Additional logic validation could be added here:
 	// - Check for unreachable nodes
 	// - Validate circular dependencies
 	// - Check for orphaned nodes

--- a/skills/validate_n8n_workflow.go
+++ b/skills/validate_n8n_workflow.go
@@ -1,0 +1,412 @@
+package skills
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	server "github.com/inference-gateway/adk/server"
+	zap "go.uber.org/zap"
+	yaml "gopkg.in/yaml.v3"
+)
+
+// ValidateN8NWorkflowSkill struct holds the skill with logger
+type ValidateN8NWorkflowSkill struct {
+	logger *zap.Logger
+}
+
+// ValidateN8nWorkflowArgs represents the input parameters for the validate_n8n_workflow skill
+type ValidateN8nWorkflowArgs struct {
+	WorkflowContent string `json:"workflow_content"`
+	Format          string `json:"format,omitempty"`
+}
+
+// N8NWorkflow represents the structure of an N8N workflow
+type N8NWorkflow struct {
+	Name        string          `json:"name,omitempty" yaml:"name,omitempty"`
+	ID          string          `json:"id,omitempty" yaml:"id,omitempty"`
+	Active      *bool           `json:"active,omitempty" yaml:"active,omitempty"`
+	Nodes       []N8NNode       `json:"nodes" yaml:"nodes"`
+	Connections []N8NConnection `json:"connections,omitempty" yaml:"connections,omitempty"`
+}
+
+// N8NNode represents an N8N workflow node
+type N8NNode struct {
+	ID         string                 `json:"id" yaml:"id"`
+	Name       string                 `json:"name" yaml:"name"`
+	Type       string                 `json:"type" yaml:"type"`
+	Parameters map[string]interface{} `json:"parameters" yaml:"parameters"`
+	Position   []float64              `json:"position" yaml:"position"`
+}
+
+// N8NConnection represents a connection between nodes
+type N8NConnection struct {
+	Source      string `json:"source" yaml:"source"`
+	Target      string `json:"target" yaml:"target"`
+	SourceIndex int    `json:"sourceIndex,omitempty" yaml:"sourceIndex,omitempty"`
+	TargetIndex int    `json:"targetIndex,omitempty" yaml:"targetIndex,omitempty"`
+}
+
+// ValidationResult represents the result of workflow validation
+type ValidationResult struct {
+	Valid    bool     `json:"valid"`
+	Errors   []string `json:"errors,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+// NewValidateN8NWorkflowSkill creates a new validate_n8n_workflow skill
+func NewValidateN8NWorkflowSkill(logger *zap.Logger) server.Tool {
+	skill := &ValidateN8NWorkflowSkill{
+		logger: logger,
+	}
+	return server.NewBasicTool(
+		"validate_n8n_workflow",
+		"Validate N8N workflow YAML/JSON to ensure it follows the correct schema and has all required attributes before creating artifacts",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"workflow_content": map[string]any{
+					"description": "The complete N8N workflow content to validate (YAML or JSON format)",
+					"type":        "string",
+				},
+				"format": map[string]any{
+					"description": "The format of the workflow content (auto-detect if not specified)",
+					"type":        "string",
+					"enum":        []string{"yaml", "json", "auto"},
+					"default":     "auto",
+				},
+			},
+			"required": []string{"workflow_content"},
+		},
+		skill.ValidateN8NWorkflowHandler,
+	)
+}
+
+// ValidateN8NWorkflowHandler handles the validate_n8n_workflow skill execution
+func (s *ValidateN8NWorkflowSkill) ValidateN8NWorkflowHandler(ctx context.Context, args map[string]any) (string, error) {
+	s.logger.Debug("ValidateN8NWorkflowHandler invoked", zap.Any("args", args))
+
+	var p ValidateN8nWorkflowArgs
+	if workflowContent, ok := args["workflow_content"].(string); ok {
+		p.WorkflowContent = strings.TrimSpace(workflowContent)
+	} else {
+		s.logger.Error("workflow_content parameter missing or invalid", zap.Any("args", args))
+		return "", fmt.Errorf("workflow_content parameter is required")
+	}
+
+	if format, ok := args["format"].(string); ok {
+		p.Format = strings.ToLower(strings.TrimSpace(format))
+	} else {
+		p.Format = "auto"
+	}
+
+	if p.WorkflowContent == "" {
+		s.logger.Error("empty workflow content provided")
+		return "", fmt.Errorf("workflow_content cannot be empty")
+	}
+
+	s.logger.Info("validating n8n workflow",
+		zap.String("format", p.Format),
+		zap.Int("content_length", len(p.WorkflowContent)))
+
+	result, err := s.validateWorkflow(p.WorkflowContent, p.Format)
+	if err != nil {
+		s.logger.Error("workflow validation failed", zap.Error(err))
+		return "", fmt.Errorf("failed to validate workflow: %v", err)
+	}
+
+	s.logger.Info("workflow validation completed",
+		zap.Bool("valid", result.Valid),
+		zap.Int("errors_count", len(result.Errors)),
+		zap.Int("warnings_count", len(result.Warnings)))
+
+	// Format the response
+	response := "## N8N Workflow Validation Result\n\n"
+
+	if result.Valid {
+		response += "✅ **Status**: VALID - Workflow passes all validation checks\n\n"
+		if len(result.Warnings) > 0 {
+			response += "⚠️ **Warnings**:\n"
+			for _, warning := range result.Warnings {
+				response += fmt.Sprintf("- %s\n", warning)
+			}
+			response += "\n"
+		}
+		response += "The workflow is ready to be saved as an artifact and can be imported into N8N."
+	} else {
+		response += "❌ **Status**: INVALID - Workflow has validation errors\n\n"
+		response += "**Errors**:\n"
+		for _, err := range result.Errors {
+			response += fmt.Sprintf("- %s\n", err)
+		}
+		if len(result.Warnings) > 0 {
+			response += "\n**Warnings**:\n"
+			for _, warning := range result.Warnings {
+				response += fmt.Sprintf("- %s\n", warning)
+			}
+		}
+		response += "\nPlease fix these issues before creating the workflow artifact."
+	}
+
+	return response, nil
+}
+
+// validateWorkflow validates the N8N workflow content
+func (s *ValidateN8NWorkflowSkill) validateWorkflow(content, format string) (*ValidationResult, error) {
+	result := &ValidationResult{
+		Valid:    true,
+		Errors:   []string{},
+		Warnings: []string{},
+	}
+
+	// Detect format if auto
+	detectedFormat := s.detectFormat(content, format)
+	s.logger.Debug("detected workflow format", zap.String("format", detectedFormat))
+
+	// Parse the workflow
+	var workflow N8NWorkflow
+	var err error
+
+	switch detectedFormat {
+	case "yaml":
+		err = yaml.Unmarshal([]byte(content), &workflow)
+		if err != nil {
+			result.Valid = false
+			result.Errors = append(result.Errors, fmt.Sprintf("Invalid YAML format: %v", err))
+			return result, nil
+		}
+	case "json":
+		err = json.Unmarshal([]byte(content), &workflow)
+		if err != nil {
+			result.Valid = false
+			result.Errors = append(result.Errors, fmt.Sprintf("Invalid JSON format: %v", err))
+			return result, nil
+		}
+	default:
+		result.Valid = false
+		result.Errors = append(result.Errors, "Unable to detect workflow format (must be valid YAML or JSON)")
+		return result, nil
+	}
+
+	// Validate workflow structure
+	s.validateWorkflowStructure(&workflow, result)
+	s.validateNodes(&workflow, result)
+	s.validateConnections(&workflow, result)
+	s.validateWorkflowLogic(&workflow, result)
+
+	return result, nil
+}
+
+// detectFormat attempts to detect the format of the workflow content
+func (s *ValidateN8NWorkflowSkill) detectFormat(content, requestedFormat string) string {
+	if requestedFormat != "auto" {
+		return requestedFormat
+	}
+
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return "unknown"
+	}
+
+	// Try JSON first (more strict)
+	var jsonTest interface{}
+	if json.Unmarshal([]byte(content), &jsonTest) == nil {
+		// Additional check to ensure it's meaningful JSON
+		if strings.HasPrefix(content, "{") && strings.HasSuffix(content, "}") {
+			return "json"
+		}
+	}
+
+	// Try YAML - but be more strict about what we accept
+	var yamlTest interface{}
+	if yaml.Unmarshal([]byte(content), &yamlTest) == nil {
+		// Check if the content is meaningful YAML (not just a plain string)
+		if strings.Contains(content, ":") || strings.Contains(content, "-") {
+			return "yaml"
+		}
+	}
+
+	return "unknown"
+}
+
+// validateWorkflowStructure validates the basic workflow structure
+func (s *ValidateN8NWorkflowSkill) validateWorkflowStructure(workflow *N8NWorkflow, result *ValidationResult) {
+	// Check if nodes array exists and is not empty
+	if len(workflow.Nodes) == 0 {
+		result.Valid = false
+		result.Errors = append(result.Errors, "Workflow must contain at least one node")
+		return
+	}
+
+	// Warn about missing optional fields
+	if workflow.Name == "" {
+		result.Warnings = append(result.Warnings, "Workflow name is not specified")
+	}
+}
+
+// validateNodes validates all nodes in the workflow
+func (s *ValidateN8NWorkflowSkill) validateNodes(workflow *N8NWorkflow, result *ValidationResult) {
+	nodeIDs := make(map[string]bool)
+	validNodeTypePattern := regexp.MustCompile(`^(n8n-nodes-base\.|@n8n/n8n-nodes-langchain\.)[\w]+$`)
+
+	for i, node := range workflow.Nodes {
+		nodePrefix := fmt.Sprintf("Node %d", i+1)
+
+		// Validate required fields
+		if node.ID == "" {
+			result.Valid = false
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: 'id' is required", nodePrefix))
+		} else {
+			// Check for duplicate IDs
+			if nodeIDs[node.ID] {
+				result.Valid = false
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: duplicate node ID '%s'", nodePrefix, node.ID))
+			}
+			nodeIDs[node.ID] = true
+		}
+
+		if node.Name == "" {
+			result.Valid = false
+			result.Errors = append(result.Errors, fmt.Sprintf("%s (%s): 'name' is required", nodePrefix, node.ID))
+		}
+
+		if node.Type == "" {
+			result.Valid = false
+			result.Errors = append(result.Errors, fmt.Sprintf("%s (%s): 'type' is required", nodePrefix, node.ID))
+		} else {
+			// Validate node type format
+			if !validNodeTypePattern.MatchString(node.Type) {
+				result.Valid = false
+				result.Errors = append(result.Errors, fmt.Sprintf("%s (%s): invalid node type format '%s'. Must follow 'n8n-nodes-base.*' or '@n8n/n8n-nodes-langchain.*' pattern", nodePrefix, node.ID, node.Type))
+			}
+		}
+
+		// Validate parameters
+		if node.Parameters == nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("%s (%s): 'parameters' is empty (should be {} if no parameters needed)", nodePrefix, node.ID))
+		}
+
+		// Validate position
+		if len(node.Position) != 2 {
+			result.Valid = false
+			result.Errors = append(result.Errors, fmt.Sprintf("%s (%s): 'position' must be an array of exactly 2 numbers [x, y]", nodePrefix, node.ID))
+		} else {
+			// Check if position values are reasonable
+			for _, pos := range node.Position {
+				if pos < 0 || pos > 10000 {
+					result.Warnings = append(result.Warnings, fmt.Sprintf("%s (%s): position coordinates seem unusual [%.0f, %.0f]", nodePrefix, node.ID, node.Position[0], node.Position[1]))
+					break
+				}
+			}
+		}
+	}
+}
+
+// validateConnections validates connections between nodes
+func (s *ValidateN8NWorkflowSkill) validateConnections(workflow *N8NWorkflow, result *ValidationResult) {
+	// Build node ID map for validation
+	nodeIDs := make(map[string]bool)
+	for _, node := range workflow.Nodes {
+		if node.ID != "" {
+			nodeIDs[node.ID] = true
+		}
+	}
+
+	if len(workflow.Nodes) <= 1 {
+		// Single node workflows don't need connections
+		if len(workflow.Connections) > 0 {
+			result.Warnings = append(result.Warnings, "Single-node workflow has connections defined (will be ignored)")
+		}
+		// Still validate any connections that exist for structural correctness
+	}
+
+	// Multi-node workflows should have connections
+	if len(workflow.Nodes) > 1 && len(workflow.Connections) == 0 {
+		result.Warnings = append(result.Warnings, "Multi-node workflow has no connections defined - nodes will not be linked")
+	}
+
+	if len(workflow.Connections) == 0 {
+		return
+	}
+
+	// Validate each connection
+	for i, conn := range workflow.Connections {
+		connPrefix := fmt.Sprintf("Connection %d", i+1)
+
+		if conn.Source == "" {
+			result.Valid = false
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: 'source' node ID is required", connPrefix))
+		} else if !nodeIDs[conn.Source] {
+			result.Valid = false
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: source node '%s' does not exist", connPrefix, conn.Source))
+		}
+
+		if conn.Target == "" {
+			result.Valid = false
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: 'target' node ID is required", connPrefix))
+		} else if !nodeIDs[conn.Target] {
+			result.Valid = false
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: target node '%s' does not exist", connPrefix, conn.Target))
+		}
+
+		// Check for self-connections
+		if conn.Source == conn.Target && conn.Source != "" {
+			result.Valid = false
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: node cannot connect to itself ('%s')", connPrefix, conn.Source))
+		}
+
+		// Validate indices
+		if conn.SourceIndex < 0 {
+			result.Valid = false
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: sourceIndex must be >= 0", connPrefix))
+		}
+		if conn.TargetIndex < 0 {
+			result.Valid = false
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: targetIndex must be >= 0", connPrefix))
+		}
+	}
+}
+
+// validateWorkflowLogic validates the logical structure of the workflow
+func (s *ValidateN8NWorkflowSkill) validateWorkflowLogic(workflow *N8NWorkflow, result *ValidationResult) {
+	triggerNodes := 0
+
+	// Check for trigger nodes
+	for _, node := range workflow.Nodes {
+		if s.isTriggerNode(node.Type) {
+			triggerNodes++
+		}
+	}
+
+	if triggerNodes == 0 {
+		result.Warnings = append(result.Warnings, "Workflow has no trigger nodes - it cannot be executed automatically")
+	}
+
+	// Additional logic validation could be added here:
+	// - Check for unreachable nodes
+	// - Validate circular dependencies
+	// - Check for orphaned nodes
+}
+
+// isTriggerNode checks if a node type is a trigger node
+func (s *ValidateN8NWorkflowSkill) isTriggerNode(nodeType string) bool {
+	triggerPatterns := []string{
+		"trigger",
+		"webhook",
+		"manual",
+		"schedule",
+		"cron",
+		"Timer",
+		"Start",
+	}
+
+	lowerType := strings.ToLower(nodeType)
+	for _, pattern := range triggerPatterns {
+		if strings.Contains(lowerType, strings.ToLower(pattern)) {
+			return true
+		}
+	}
+	return false
+}

--- a/skills/validate_n8n_workflow_test.go
+++ b/skills/validate_n8n_workflow_test.go
@@ -2,6 +2,7 @@ package skills
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"go.uber.org/zap"
@@ -262,7 +263,7 @@ nodes:
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("expected error but got none")
-				} else if tt.errorContains != "" && !contains(err.Error(), tt.errorContains) {
+				} else if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
 					t.Errorf("expected error to contain %q, got %q", tt.errorContains, err.Error())
 				}
 				return
@@ -273,13 +274,13 @@ nodes:
 				return
 			}
 
-			if tt.resultContains != "" && !contains(result, tt.resultContains) {
+			if tt.resultContains != "" && !strings.Contains(result, tt.resultContains) {
 				t.Errorf("expected result to contain %q, got %q", tt.resultContains, result)
 			}
 
-			if tt.expectValid && contains(result, "INVALID") {
+			if tt.expectValid && strings.Contains(result, "INVALID") {
 				t.Errorf("expected valid workflow but got invalid result: %s", result)
-			} else if !tt.expectValid && contains(result, "VALID") && !contains(result, "INVALID") {
+			} else if !tt.expectValid && strings.Contains(result, "VALID") && !strings.Contains(result, "INVALID") {
 				t.Errorf("expected invalid workflow but got valid result: %s", result)
 			}
 		})
@@ -365,15 +366,3 @@ func TestIsTriggerNode(t *testing.T) {
 	}
 }
 
-// Helper function to check if a string contains a substring
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) &&
-		(len(substr) == 0 || func() bool {
-			for i := 0; i <= len(s)-len(substr); i++ {
-				if s[i:i+len(substr)] == substr {
-					return true
-				}
-			}
-			return false
-		}())
-}

--- a/skills/validate_n8n_workflow_test.go
+++ b/skills/validate_n8n_workflow_test.go
@@ -277,7 +277,6 @@ nodes:
 				t.Errorf("expected result to contain %q, got %q", tt.resultContains, result)
 			}
 
-			// Check if validation result matches expectation
 			if tt.expectValid && contains(result, "INVALID") {
 				t.Errorf("expected valid workflow but got invalid result: %s", result)
 			} else if !tt.expectValid && contains(result, "VALID") && !contains(result, "INVALID") {

--- a/skills/validate_n8n_workflow_test.go
+++ b/skills/validate_n8n_workflow_test.go
@@ -1,0 +1,380 @@
+package skills
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestValidateN8NWorkflowHandler(t *testing.T) {
+	logger := zap.NewNop()
+	skill := &ValidateN8NWorkflowSkill{logger: logger}
+
+	tests := []struct {
+		name           string
+		args           map[string]any
+		expectError    bool
+		expectValid    bool
+		errorContains  string
+		resultContains string
+	}{
+		{
+			name: "valid simple workflow yaml",
+			args: map[string]any{
+				"workflow_content": `
+name: "Test Workflow"
+nodes:
+  - id: "trigger"
+    name: "Manual Trigger"
+    type: "n8n-nodes-base.manualTrigger"
+    parameters: {}
+    position: [20, 20]
+  - id: "action"
+    name: "HTTP Request"
+    type: "n8n-nodes-base.httpRequest"
+    parameters:
+      method: "GET"
+      url: "https://api.example.com"
+    position: [220, 20]
+connections:
+  - source: "trigger"
+    target: "action"
+    sourceIndex: 0
+    targetIndex: 0
+`,
+				"format": "yaml",
+			},
+			expectError:    false,
+			expectValid:    true,
+			resultContains: "VALID",
+		},
+		{
+			name: "valid simple workflow json",
+			args: map[string]any{
+				"workflow_content": `{
+  "name": "Test Workflow",
+  "nodes": [
+    {
+      "id": "trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "parameters": {},
+      "position": [20, 20]
+    }
+  ]
+}`,
+				"format": "json",
+			},
+			expectError:    false,
+			expectValid:    true,
+			resultContains: "VALID",
+		},
+		{
+			name: "missing workflow_content parameter",
+			args: map[string]any{
+				"format": "yaml",
+			},
+			expectError:   true,
+			errorContains: "workflow_content parameter is required",
+		},
+		{
+			name: "empty workflow_content",
+			args: map[string]any{
+				"workflow_content": "",
+				"format":           "yaml",
+			},
+			expectError:   true,
+			errorContains: "workflow_content cannot be empty",
+		},
+		{
+			name: "invalid yaml format",
+			args: map[string]any{
+				"workflow_content": "invalid: yaml: content: [unclosed",
+				"format":           "yaml",
+			},
+			expectError:    false,
+			expectValid:    false,
+			resultContains: "Invalid YAML format",
+		},
+		{
+			name: "invalid json format",
+			args: map[string]any{
+				"workflow_content": `{"invalid": json content}`,
+				"format":           "json",
+			},
+			expectError:    false,
+			expectValid:    false,
+			resultContains: "Invalid JSON format",
+		},
+		{
+			name: "workflow with no nodes",
+			args: map[string]any{
+				"workflow_content": `
+name: "Empty Workflow"
+nodes: []
+`,
+				"format": "yaml",
+			},
+			expectError:    false,
+			expectValid:    false,
+			resultContains: "must contain at least one node",
+		},
+		{
+			name: "workflow with missing node id",
+			args: map[string]any{
+				"workflow_content": `
+nodes:
+  - name: "Test Node"
+    type: "n8n-nodes-base.manualTrigger"
+    parameters: {}
+    position: [20, 20]
+`,
+				"format": "yaml",
+			},
+			expectError:    false,
+			expectValid:    false,
+			resultContains: "'id' is required",
+		},
+		{
+			name: "workflow with invalid node type",
+			args: map[string]any{
+				"workflow_content": `
+nodes:
+  - id: "test"
+    name: "Test Node"
+    type: "invalid-node-type"
+    parameters: {}
+    position: [20, 20]
+`,
+				"format": "yaml",
+			},
+			expectError:    false,
+			expectValid:    false,
+			resultContains: "invalid node type format",
+		},
+		{
+			name: "workflow with invalid position",
+			args: map[string]any{
+				"workflow_content": `
+nodes:
+  - id: "test"
+    name: "Test Node"
+    type: "n8n-nodes-base.manualTrigger"
+    parameters: {}
+    position: [20]
+`,
+				"format": "yaml",
+			},
+			expectError:    false,
+			expectValid:    false,
+			resultContains: "must be an array of exactly 2 numbers",
+		},
+		{
+			name: "workflow with duplicate node ids",
+			args: map[string]any{
+				"workflow_content": `
+nodes:
+  - id: "duplicate"
+    name: "Node 1"
+    type: "n8n-nodes-base.manualTrigger"
+    parameters: {}
+    position: [20, 20]
+  - id: "duplicate"
+    name: "Node 2"
+    type: "n8n-nodes-base.httpRequest"
+    parameters: {}
+    position: [220, 20]
+`,
+				"format": "yaml",
+			},
+			expectError:    false,
+			expectValid:    false,
+			resultContains: "duplicate node ID",
+		},
+		{
+			name: "workflow with invalid connection reference",
+			args: map[string]any{
+				"workflow_content": `
+nodes:
+  - id: "trigger"
+    name: "Manual Trigger"
+    type: "n8n-nodes-base.manualTrigger"
+    parameters: {}
+    position: [20, 20]
+connections:
+  - source: "trigger"
+    target: "nonexistent"
+    sourceIndex: 0
+    targetIndex: 0
+`,
+				"format": "yaml",
+			},
+			expectError:    false,
+			expectValid:    false,
+			resultContains: "does not exist",
+		},
+		{
+			name: "workflow with self-connection",
+			args: map[string]any{
+				"workflow_content": `
+nodes:
+  - id: "trigger"
+    name: "Manual Trigger"
+    type: "n8n-nodes-base.manualTrigger"
+    parameters: {}
+    position: [20, 20]
+connections:
+  - source: "trigger"
+    target: "trigger"
+    sourceIndex: 0
+    targetIndex: 0
+`,
+				"format": "yaml",
+			},
+			expectError:    false,
+			expectValid:    false,
+			resultContains: "cannot connect to itself",
+		},
+		{
+			name: "langchain node type validation",
+			args: map[string]any{
+				"workflow_content": `
+nodes:
+  - id: "ai"
+    name: "OpenAI Chat"
+    type: "@n8n/n8n-nodes-langchain.lmChatOpenAi"
+    parameters: {}
+    position: [20, 20]
+`,
+				"format": "yaml",
+			},
+			expectError:    false,
+			expectValid:    true,
+			resultContains: "VALID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := skill.ValidateN8NWorkflowHandler(context.Background(), tt.args)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				} else if tt.errorContains != "" && !contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error to contain %q, got %q", tt.errorContains, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if tt.resultContains != "" && !contains(result, tt.resultContains) {
+				t.Errorf("expected result to contain %q, got %q", tt.resultContains, result)
+			}
+
+			// Check if validation result matches expectation
+			if tt.expectValid && contains(result, "INVALID") {
+				t.Errorf("expected valid workflow but got invalid result: %s", result)
+			} else if !tt.expectValid && contains(result, "VALID") && !contains(result, "INVALID") {
+				t.Errorf("expected invalid workflow but got valid result: %s", result)
+			}
+		})
+	}
+}
+
+func TestDetectFormat(t *testing.T) {
+	logger := zap.NewNop()
+	skill := &ValidateN8NWorkflowSkill{logger: logger}
+
+	tests := []struct {
+		name            string
+		content         string
+		requestedFormat string
+		expected        string
+	}{
+		{
+			name:            "explicit yaml format",
+			content:         "name: test\nnodes: []",
+			requestedFormat: "yaml",
+			expected:        "yaml",
+		},
+		{
+			name:            "explicit json format",
+			content:         `{"name": "test", "nodes": []}`,
+			requestedFormat: "json",
+			expected:        "json",
+		},
+		{
+			name:            "auto-detect json",
+			content:         `{"name": "test", "nodes": []}`,
+			requestedFormat: "auto",
+			expected:        "json",
+		},
+		{
+			name:            "auto-detect yaml",
+			content:         "name: test\nnodes: []",
+			requestedFormat: "auto",
+			expected:        "yaml",
+		},
+		{
+			name:            "invalid content",
+			content:         "invalid content",
+			requestedFormat: "auto",
+			expected:        "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := skill.detectFormat(tt.content, tt.requestedFormat)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestIsTriggerNode(t *testing.T) {
+	logger := zap.NewNop()
+	skill := &ValidateN8NWorkflowSkill{logger: logger}
+
+	tests := []struct {
+		name     string
+		nodeType string
+		expected bool
+	}{
+		{"manual trigger", "n8n-nodes-base.manualTrigger", true},
+		{"webhook", "n8n-nodes-base.webhook", true},
+		{"schedule trigger", "n8n-nodes-base.scheduleTrigger", true},
+		{"http request", "n8n-nodes-base.httpRequest", false},
+		{"code node", "n8n-nodes-base.code", false},
+		{"cron trigger", "n8n-nodes-base.cronTrigger", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := skill.isTriggerNode(tt.nodeType)
+			if result != tt.expected {
+				t.Errorf("expected %v for %q, got %v", tt.expected, tt.nodeType, result)
+			}
+		})
+	}
+}
+
+// Helper function to check if a string contains a substring
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) &&
+		(len(substr) == 0 || func() bool {
+			for i := 0; i <= len(s)-len(substr); i++ {
+				if s[i:i+len(substr)] == substr {
+					return true
+				}
+			}
+			return false
+		}())
+}


### PR DESCRIPTION
Implements the N8N workflow validation skill as requested in #issue-12.

## Changes
- Added `validate_n8n_workflow` skill to agent.yaml with comprehensive schema validation
- Implemented validation logic for required fields, node types, and connections
- Updated system prompt to require validation before artifact creation
- Added comprehensive test suite with 14 test cases
- All acceptance criteria met

Generated with [Claude Code](https://claude.ai/code)